### PR TITLE
Allow setting of absolute paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ const checkDataTypeCompatibility = (params) => {
     return allowedParamsDataTypes.includes(typeof params)
 }
 
+const checkIfAbsolutePath = path => path.startsWith('/') || path.startsWith('~/');
+
 
 module.exports = function openssl(params, callback = () => undefined) {
     const stdout = [];
@@ -66,7 +68,7 @@ module.exports = function openssl(params, callback = () => undefined) {
             parameters[i] = dir + parameters[i];            
         }
 
-        if (checkCommandForIO(parameters[i]) && typeof parameters[i + 1] !== 'object') {
+        if (checkCommandForIO(parameters[i]) && typeof parameters[i + 1] !== 'object' && !checkIfAbsolutePath(parameters[i +1])) {
             parameters[i + 1] = dir + parameters[i + 1];
         }
     }


### PR DESCRIPTION
Enforcing that all input passed to parameters like `-in` and `-out` be prefixed with `openssl/` is a bit restrictive, particularly for `-in`, as the intention there is to be able to specify an existing source file that you have for conversion.

This PR allows the IO parameters to be set as an absolute path. If the value starts with either `/` or `~/`, it will not add `openssl/` to the start of it; if it starts with any other character, then the old behaviour prevails.


Proposed in base repo here: `https://github.com/codevibess/openssl-nodejs/pull/14` (forked here for now for speed of update; not sure how maintained the original package is currently)